### PR TITLE
Update CKEditorViewerForMendix.js

### DIFF
--- a/src/CKEditorForMendix/widget/CKEditorViewerForMendix.js
+++ b/src/CKEditorForMendix/widget/CKEditorViewerForMendix.js
@@ -87,7 +87,7 @@ require({
 
 			if(this._contextObj) {
 				
-				domStyle.set(this.domNode, "display", "initial");
+				domStyle.set(this.domNode, "display", "inline");
 				var html = this._contextObj.get(this.messageString),
 					name = Date.now();
 


### PR DESCRIPTION
IE doesn't support display: initial. In IE the widgets remains hidden.
Also see http://stackoverflow.com/questions/18851042/div-displayinitial-not-working-as-intended-in-ie10-and-chrome-29