### PR TITLE
Added browser spell-check option

### DIFF
--- a/src/CKEditorForMendix/CKEditorForMendix.xml
+++ b/src/CKEditorForMendix/CKEditorForMendix.xml
@@ -51,6 +51,11 @@
             <category>Behavior</category>
             <description>Whether to automatically create wrapping blocks around inline content inside the document body. (This option is deprecated. Changing the default value (true) might introduce unpredictable usability issues and is highly unrecommended.)</description>
         </property>
+		<property key="enableSpellCheck" type="boolean" required="true" defaultValue="true">
+            <caption>Spell-checker</caption>
+            <category>Behavior</category>
+            <description>Whether to apply the browser's spell checking to the input area.</description>
+        </property>
         <property key="toolbarDocument" type="boolean" required="true" defaultValue="true">
             <caption>Toolbar</caption>
             <category>Document</category>

--- a/src/CKEditorForMendix/widget/CKEditorForMendix.js
+++ b/src/CKEditorForMendix/widget/CKEditorForMendix.js
@@ -397,6 +397,9 @@ define([
 
             // Set autoparagraph
             this._editor.config.autoParagraph  = this.autoParagraph;
+			
+			// Set spellchecker
+			this._editor.config.disableNativeSpellChecker = !this.enableSpellCheck; // Enable or disable spellchecking
 
             // Attach Mendix Widget to editor and pass the mendix widget configuration to the CKEditor.
             this._editor.mendixWidget = this;


### PR DESCRIPTION
Added an option to enable the browser's spell-checking functionality in the editor.
- Added a boolean option in the widget xml under Behavior
- Added option to editor configuration when initializing
